### PR TITLE
Support new Cacti 'Roles'

### DIFF
--- a/include/settings.php
+++ b/include/settings.php
@@ -251,6 +251,10 @@ function intropage_config_settings() {
 
 	$tabs['intropage']     = 'Intropage';
 	$settings['intropage'] = $intropage_settings;
+
+	if (function_exists('auth_augment_roles')) {
+		auth_augment_roles(__('Normal User'), array('intropage.php'));
+	}
 }
 
 function intropage_login_options_navigate() {


### PR DESCRIPTION
This change will allow Intropage to properly support the extension of Cacti Roles in 1.2.11.  This will not impact prior Cacti releases.