### PR TITLE
Fixing Issues #120 and #121

### DIFF
--- a/include/settings.php
+++ b/include/settings.php
@@ -307,7 +307,7 @@ function intropage_console_after() {
 
 function intropage_user_admin_tab() {
 	global $config;
-	
+
 	print '<li class="subTab">';
 
 	if (get_request_var_request("tab") == "intropage_settings_edit") {
@@ -379,11 +379,13 @@ function intropage_user_admin_user_save($save){
 
 	foreach ($panels as $panel) {
 		if ($panel['panel_id'] != 'admin_alert' && $panel['panel_id'] != 'maint') {
-			db_execute('update plugin_intropage_user_auth set ' . $panel['panel_id'] . '="' . get_nfilter_request_var($panel['panel_id']) .
-			'" WHERE user_id = ' . get_request_var('id'));
+			db_execute_prepared('UPDATE plugin_intropage_user_auth
+				SET `' . $panel['panel_id'] . '` = ?
+				WHERE user_id = ?',
+				array(get_nfilter_request_var($panel['panel_id']), get_nfilter_request_var('id')));
 		}
 	}
-	
+
 	return ($save);
 }
 

--- a/include/variables.php
+++ b/include/variables.php
@@ -51,13 +51,16 @@ $intropage_settings = array(	// default values
 		'friendly_name' => __('Poller Timeout'),
 		'description' => __('The amount of time, in minutes, that the Intropage background poller can run before being interrupted and killed by Cacti.'),
 		'method' => 'drop_array',
-		'default' => '300',
+		'default' => '1800',
 		'array' => array(
 			60   => __('%d Minute', 1),
 			300  => __('%d Minutes', 5),
 			600  => __('%d Minutes', 10),
-			900  => __('%d Seconds', 15),
-			1200 => __('%d Seconds', 20)
+			900  => __('%d Minutes', 15),
+			1200 => __('%d Minutes', 20),
+			1800 => __('%d Minutes', 30),
+			2400 => __('%d Minutes', 40),
+			3600 => __('%d Hour', 1)
 		)
 	),
 	'intropage_analyse_log_rows' => array(


### PR DESCRIPTION
* Validation warnings and SQL Injection bug
* Iniial Poller poller run times out due to vary large tables causing crashes
* Add some more timeout settings
* Change the default to 1800 seconds